### PR TITLE
Add virtual enviroment ignore rule into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+venv
+
+__pycache__
+.pytest_cache
+
 .vscode
 .idea


### PR DESCRIPTION
Write `venv`, `__pycache__` and `.pytest_cache` on `.gitignore` in order to ignore virtual environment and cache files.